### PR TITLE
Add request body as oauth body params 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,6 @@ libraryDependencies ++= Seq(
   "org.slf4j"               %  "slf4j-api"                % "1.7.26",
   "com.softwaremill.sttp"   %% "core"                     % "1.6.2",
   "com.github.scribejava"   %  "scribejava-apis"          % "6.3.0",
-  "org.scala-lang.modules"  %% "scala-collection-compat"  % "2.1.1",
   "org.scalatest"           %% "scalatest"                % "3.0.8"   % Test
 )
 


### PR DESCRIPTION
When content type is `application/x-www-form-urlencoded`, add the request body using `OAuthRequest.addBodyParameter` to ensure that it is included in the OAuth signature.

Removed the `scala-collection-compat` dependency in favour of using a plain List, as it was causing a NoClassDefFoundError at runtime.