### PR TITLE
Try to get a partial response when input stream closes unexpectedly

### DIFF
--- a/src/main/scala/software/purpledragon/sttp/scribe/ScribeBackend.scala
+++ b/src/main/scala/software/purpledragon/sttp/scribe/ScribeBackend.scala
@@ -28,7 +28,6 @@ import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.collection.{immutable, mutable}
 import scala.io.Source
-import scala.util.Try
 import scala.language.higherKinds
 import java.net.URLDecoder
 
@@ -81,7 +80,7 @@ abstract class ScribeBackend(service: OAuthService) extends SttpBackend[Id, Noth
     val body: Either[Array[Byte], T] = if (StatusCodes.isSuccess(statusCode)) {
       Right(readResponseBody(is, responseAs, charsetFromHeaders, metadata))
     } else {
-      val bytes = Try(toByteArray(is)).getOrElse(Array.emptyByteArray)
+      val bytes = toByteArray(is)
       Left(bytes)
     }
 

--- a/src/main/scala/software/purpledragon/sttp/scribe/ScribeBackend.scala
+++ b/src/main/scala/software/purpledragon/sttp/scribe/ScribeBackend.scala
@@ -28,6 +28,7 @@ import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.collection.{immutable, mutable}
 import scala.io.Source
+import scala.util.Try
 import scala.language.higherKinds
 import java.net.URLDecoder
 
@@ -80,7 +81,8 @@ abstract class ScribeBackend(service: OAuthService) extends SttpBackend[Id, Noth
     val body: Either[Array[Byte], T] = if (StatusCodes.isSuccess(statusCode)) {
       Right(readResponseBody(is, responseAs, charsetFromHeaders, metadata))
     } else {
-      Left(toByteArray(is))
+      val bytes = Try(toByteArray(is)).getOrElse(Array.emptyByteArray)
+      Left(bytes)
     }
 
     Response(body, statusCode, r.getMessage, headers, Nil)

--- a/src/main/scala/software/purpledragon/sttp/scribe/package.scala
+++ b/src/main/scala/software/purpledragon/sttp/scribe/package.scala
@@ -17,13 +17,14 @@
 package software.purpledragon.sttp
 
 import java.io.{ByteArrayOutputStream, InputStream, OutputStream}
+import scala.util.Try
 
 package object scribe {
   private[sttp] def transfer(is: InputStream, os: OutputStream): Unit = {
     val buffer = new Array[Byte](1024)
 
     Iterator
-      .continually(is.read(buffer))
+      .continually(Try(is.read(buffer)).getOrElse(-1))
       .takeWhile(_ != -1)
       .foreach(count => os.write(buffer, 0, count))
   }


### PR DESCRIPTION
Noticed that we are sometimes throwing away the response when an error occurs from a failed request, this is an attempt to avoid that