### PR TITLE
Make query param encoding consistent with scribe

### DIFF
--- a/src/main/scala/software/purpledragon/sttp/scribe/ScribeBackend.scala
+++ b/src/main/scala/software/purpledragon/sttp/scribe/ScribeBackend.scala
@@ -30,11 +30,16 @@ import scala.collection.{immutable, mutable}
 import scala.io.Source
 import scala.language.higherKinds
 import java.net.URLDecoder
+import com.github.scribejava.core.utils.OAuthEncoder
 
 abstract class ScribeBackend(service: OAuthService) extends SttpBackend[Id, Nothing] {
   override def send[T](request: Request[T, Nothing]): Id[Response[T]] = {
-    val oAuthRequest = new OAuthRequest(method2Verb(request.method), request.uri.toString())
+    val urlWithoutParams = request.uri.copy(queryFragments = Nil).toString
+    val oAuthRequest = new OAuthRequest(method2Verb(request.method), urlWithoutParams)
 
+    request.uri.paramsSeq foreach {
+      case (name, value) => oAuthRequest.addQuerystringParameter(name, value)
+    }
     request.headers foreach {
       case (name, value) => oAuthRequest.addHeader(name, value)
     }

--- a/src/main/scala/software/purpledragon/sttp/scribe/ScribeBackend.scala
+++ b/src/main/scala/software/purpledragon/sttp/scribe/ScribeBackend.scala
@@ -28,7 +28,6 @@ import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.collection.{immutable, mutable}
 import scala.io.Source
-import scala.util.Try
 import scala.language.higherKinds
 import java.net.URLDecoder
 
@@ -81,7 +80,7 @@ abstract class ScribeBackend(service: OAuthService) extends SttpBackend[Id, Noth
     val body: Either[Array[Byte], T] = if (StatusCodes.isSuccess(statusCode)) {
       Right(readResponseBody(is, responseAs, charsetFromHeaders, metadata))
     } else {
-      val bytes = Try(toByteArray(is)).getOrElse(Array.emptyByteArray)
+      val bytes = toByteArray(is)
       Left(bytes)
     }
 

--- a/src/main/scala/software/purpledragon/sttp/scribe/ScribeBackend.scala
+++ b/src/main/scala/software/purpledragon/sttp/scribe/ScribeBackend.scala
@@ -28,6 +28,7 @@ import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.collection.{immutable, mutable}
 import scala.io.Source
+import scala.util.Try
 import scala.language.higherKinds
 import java.net.URLDecoder
 
@@ -80,7 +81,8 @@ abstract class ScribeBackend(service: OAuthService) extends SttpBackend[Id, Noth
     val body: Either[Array[Byte], T] = if (StatusCodes.isSuccess(statusCode)) {
       Right(readResponseBody(is, responseAs, charsetFromHeaders, metadata))
     } else {
-      Left(toByteArray(is))
+      val bytes = Try(toByteArray(is)).getOrElse(Array.emptyByteArray)
+      Left(bytes)
     }
 
     Response(body, statusCode, r.getMessage, headers, Nil)

--- a/src/main/scala/software/purpledragon/sttp/scribe/ScribeOAuth10aBackend.scala
+++ b/src/main/scala/software/purpledragon/sttp/scribe/ScribeOAuth10aBackend.scala
@@ -19,12 +19,17 @@ package software.purpledragon.sttp.scribe
 import com.github.scribejava.core.model.{OAuth1AccessToken, OAuthRequest, Response, Verb}
 import com.github.scribejava.core.oauth.OAuth10aService
 import com.github.scribejava.core.exceptions.OAuthException
+import software.purpledragon.sttp.scribe.QueryParamEncodingStyle.Sttp
 
-class ScribeOAuth10aBackend(service: OAuth10aService, tokenProvider: OAuth1TokenProvider)
-    extends ScribeBackend(service)
-    with Logging {
+class ScribeOAuth10aBackend(service: OAuth10aService,
+                            tokenProvider: OAuth1TokenProvider,
+                            encodingStyle: QueryParamEncodingStyle = Sttp) extends ScribeBackend(service) with Logging {
 
   private var oauthToken: Option[OAuth1AccessToken] = None
+
+  override final def withEncodingStyle(style: QueryParamEncodingStyle): ScribeOAuth10aBackend = {
+    new ScribeOAuth10aBackend(service, tokenProvider, style)
+  }
 
   override protected def signRequest(request: OAuthRequest): Unit = {
     service.signRequest(currentToken, request)

--- a/src/main/scala/software/purpledragon/sttp/scribe/ScribeOAuth20Backend.scala
+++ b/src/main/scala/software/purpledragon/sttp/scribe/ScribeOAuth20Backend.scala
@@ -19,13 +19,19 @@ package software.purpledragon.sttp.scribe
 import com.github.scribejava.core.exceptions.OAuthException
 import com.github.scribejava.core.model.{OAuth2AccessToken, OAuthRequest, Response}
 import com.github.scribejava.core.oauth.OAuth20Service
+import software.purpledragon.sttp.scribe.QueryParamEncodingStyle.Sttp
 
 class ScribeOAuth20Backend(
     service: OAuth20Service,
     tokenProvider: OAuth2TokenProvider,
-    grantType: OAuth2GrantType = OAuth2GrantType.AuthorizationCode) extends ScribeBackend(service) with Logging {
+    grantType: OAuth2GrantType = OAuth2GrantType.AuthorizationCode,
+    encodingStyle: QueryParamEncodingStyle = Sttp) extends ScribeBackend(service, encodingStyle) with Logging {
 
   private var oauthToken: Option[OAuth2AccessToken] = None
+
+  override final def withEncodingStyle(style: QueryParamEncodingStyle): ScribeOAuth20Backend = {
+    new ScribeOAuth20Backend(service, tokenProvider, grantType, style)
+  }
 
   override protected def signRequest(request: OAuthRequest): Unit = {
     service.signRequest(currentToken, request)

--- a/src/main/scala/software/purpledragon/sttp/scribe/package.scala
+++ b/src/main/scala/software/purpledragon/sttp/scribe/package.scala
@@ -17,13 +17,14 @@
 package software.purpledragon.sttp
 
 import java.io.{ByteArrayOutputStream, InputStream, OutputStream}
+import scala.util.Try
 
 package object scribe {
   private[sttp] def transfer(is: InputStream, os: OutputStream): Unit = {
     val buffer = new Array[Byte](1024)
 
     Iterator
-      .continually(is.read(buffer))
+      .continually(Try(is.read(buffer)).getOrElse(-1))
       .takeWhile(_ != -1)
       .foreach(count => os.write(buffer, 0, count))
   }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.5.3-SNAPSHOT"
+version in ThisBuild := "1.6.0-SNAPSHOT"


### PR DESCRIPTION
Url query param encoding is handled slightly differently by scribe and sttp. This ensures we use scribe's implementation to encode query parameters.