### PR TITLE
Adapt backend to enable making requests asynchronously

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ target
 *.sc
 
 .DS_Store
+
+.bloop/
+.bsp/
+.metals/
+metals.sbt

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sttp-scribe - sttp backend for ScribeJava
 
-[![Build Status](https://img.shields.io/travis/stringbean/sttp-scribe/master.svg)](https://travis-ci.org/stringbean/sttp-scribe)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/stringbean/sttp-scribe/ci.yml)](https://github.com/stringbean/sttp-scribe/actions/workflows/ci.yml)
 [![Codacy Grade](https://img.shields.io/codacy/grade/6becacf763074472b1360c0d41cd8478.svg?label=codacy)](https://www.codacy.com/app/stringbean/sttp-scribe)
 [![Test Coverage](https://img.shields.io/codecov/c/github/stringbean/sttp-scribe/master.svg)](https://codecov.io/gh/stringbean/sttp-scribe)
 [![Maven Central - Scala 2.12](https://img.shields.io/maven-central/v/software.purpledragon/sttp-scribe_2.12.svg?label=scala%202.12)](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22sttp-scribe_2.12%22)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Build Status](https://img.shields.io/travis/stringbean/sttp-scribe/master.svg)](https://travis-ci.org/stringbean/sttp-scribe)
 [![Codacy Grade](https://img.shields.io/codacy/grade/6becacf763074472b1360c0d41cd8478.svg?label=codacy)](https://www.codacy.com/app/stringbean/sttp-scribe)
 [![Test Coverage](https://img.shields.io/codecov/c/github/stringbean/sttp-scribe/master.svg)](https://codecov.io/gh/stringbean/sttp-scribe)
-[![Maven Central - Scala 2.11](https://img.shields.io/maven-central/v/software.purpledragon/sttp-scribe_2.11.svg?label=scala%202.11)](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22sttp-scribe_2.11%22)
 [![Maven Central - Scala 2.12](https://img.shields.io/maven-central/v/software.purpledragon/sttp-scribe_2.12.svg?label=scala%202.12)](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22sttp-scribe_2.12%22)
 [![Maven Central - Scala 2.13](https://img.shields.io/maven-central/v/software.purpledragon/sttp-scribe_2.13.svg?label=scala%202.13)](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22sttp-scribe_2.13%22)
 

--- a/build.sbt
+++ b/build.sbt
@@ -69,5 +69,5 @@ mimaPreviousArtifacts := Set("software.purpledragon" %% "sttp-scribe" % "2.0.1")
 
 libraryDependencySchemes ++= Seq(
   // override version scheme to prevent version conflict
-  "org.scala-lang.modules" %% "scala-java8-compat" % VersionScheme.Always
+  "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 )

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import sbt.librarymanagement.{ SemanticSelector, VersionNumber }
+import sbt.librarymanagement.{SemanticSelector, VersionNumber}
 name         := "sttp-scribe"
 organization := "software.purpledragon"
 
@@ -66,17 +66,4 @@ releaseProcess := Seq[ReleaseStep](
   pushChanges
 )
 
-libraryDependencySchemes ++= Seq(
-  // override version scheme to prevent version conflict
-  "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
-)
-
-mimaPreviousArtifacts := {
-  if (VersionNumber(version.value).matchesSemVer(SemanticSelector(">=3.0.0-SNAPSHOT"))) {
-    Set.empty
-  } else {
-    Set(
-      "software.purpledragon" %% "sttp-scribe" % "2.0.1",
-      "software.purpledragon" %% "sttp-scribe" % "2.0.2")
-  }
-}
+mimaPreviousArtifacts := Set.empty

--- a/build.sbt
+++ b/build.sbt
@@ -66,3 +66,8 @@ releaseProcess := Seq[ReleaseStep](
 )
 
 mimaPreviousArtifacts := Set("software.purpledragon" %% "sttp-scribe" % "2.0.1")
+
+libraryDependencySchemes ++= Seq(
+  // override version scheme to prevent version conflict
+  "org.scala-lang.modules" %% "scala-java8-compat" % VersionScheme.Always
+)

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,8 @@
-import sbt.librarymanagement.{SemanticSelector, VersionNumber}
 name         := "sttp-scribe"
 organization := "software.purpledragon"
 
 scalaVersion       := "2.13.14"
-crossScalaVersions := Seq(scalaVersion.value, "2.11.12", "2.12.19")
+crossScalaVersions := Seq(scalaVersion.value, "2.12.19")
 
 libraryDependencies ++= Seq(
   "org.slf4j"                     % "slf4j-api"               % "1.7.36",
@@ -43,7 +42,7 @@ scmInfo              := Some(
 )
 publishTo            := sonatypePublishToBundle.value
 
-import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations._
+import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations.*
 
 releaseCrossBuild             := true
 releasePublishArtifactsAction := PgpKeys.publishSigned.value

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ libraryDependencies ++= Seq(
   "com.github.scribejava"         % "scribejava-apis"         % "6.9.0",
   "org.scala-lang.modules"       %% "scala-collection-compat" % "2.12.0",
   "com.github.bigwheel"          %% "util-backports"          % "2.1",
+  "org.scala-lang.modules"       %% "scala-java8-compat"      % "1.0.2",
   "org.scalatest"                %% "scalatest"               % "3.2.18" % Test,
   "org.scalamock"                %% "scalamock"               % "5.2.0"  % Test,
   "commons-io"                    % "commons-io"              % "2.16.1" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import sbt.librarymanagement.{ SemanticSelector, VersionNumber }
 name         := "sttp-scribe"
 organization := "software.purpledragon"
 
@@ -65,9 +66,17 @@ releaseProcess := Seq[ReleaseStep](
   pushChanges
 )
 
-mimaPreviousArtifacts := Set("software.purpledragon" %% "sttp-scribe" % "2.0.1")
-
 libraryDependencySchemes ++= Seq(
   // override version scheme to prevent version conflict
   "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 )
+
+mimaPreviousArtifacts := {
+  if (VersionNumber(version.value).matchesSemVer(SemanticSelector(">=3.0.0-SNAPSHOT"))) {
+    Set.empty
+  } else {
+    Set(
+      "software.purpledragon" %% "sttp-scribe" % "2.0.1",
+      "software.purpledragon" %% "sttp-scribe" % "2.0.2")
+  }
+}

--- a/src/main/scala/software/purpledragon/sttp/scribe/MonadAdaptor.scala
+++ b/src/main/scala/software/purpledragon/sttp/scribe/MonadAdaptor.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Michael Stringer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package software.purpledragon.sttp.scribe
 
 import com.github.scribejava.core.model.{OAuthRequest, Response}

--- a/src/main/scala/software/purpledragon/sttp/scribe/MonadAdaptor.scala
+++ b/src/main/scala/software/purpledragon/sttp/scribe/MonadAdaptor.scala
@@ -1,13 +1,13 @@
 package software.purpledragon.sttp.scribe
 
-import com.github.scribejava.core.model.Response
+import com.github.scribejava.core.model.{OAuthRequest, Response}
 import com.github.scribejava.core.oauth.OAuthService
-import com.github.scribejava.core.model.OAuthRequest
 import sttp.client.Identity
-import scala.concurrent.Future
-import scala.compat.java8.FutureConverters._
+
 import java.util.concurrent.CompletableFuture
 import java.util.function.Supplier
+import scala.compat.java8.FutureConverters._
+import scala.concurrent.Future
 
 trait MonadAdaptor[F[_]] {
   def executeRequest(service: OAuthService, request: OAuthRequest): F[Response]
@@ -26,9 +26,11 @@ object MonadAdaptor {
     implicit val future: MonadAdaptor[Future] = new MonadAdaptor[Future] {
       def executeRequest(service: OAuthService, request: OAuthRequest): Future[Response] = {
         val javaFuture = service.executeAsync(request)
-        CompletableFuture.supplyAsync(new Supplier[Response] {
-          def get(): Response = javaFuture.get()
-        }).toScala
+        CompletableFuture
+          .supplyAsync(new Supplier[Response] {
+            def get(): Response = javaFuture.get()
+          })
+          .toScala
       }
     }
   }

--- a/src/main/scala/software/purpledragon/sttp/scribe/MonadAdaptor.scala
+++ b/src/main/scala/software/purpledragon/sttp/scribe/MonadAdaptor.scala
@@ -1,0 +1,35 @@
+package software.purpledragon.sttp.scribe
+
+import com.github.scribejava.core.model.Response
+import com.github.scribejava.core.oauth.OAuthService
+import com.github.scribejava.core.model.OAuthRequest
+import sttp.client.Identity
+import scala.concurrent.Future
+import scala.compat.java8.FutureConverters._
+import java.util.concurrent.CompletableFuture
+import java.util.function.Supplier
+
+trait MonadAdaptor[F[_]] {
+  def executeRequest(service: OAuthService, request: OAuthRequest): F[Response]
+}
+
+object MonadAdaptor {
+
+  object Implicits {
+
+    implicit val identity: MonadAdaptor[Identity] = new MonadAdaptor[Identity] {
+      def executeRequest(service: OAuthService, request: OAuthRequest): Response = {
+        service.execute(request)
+      }
+    }
+
+    implicit val future: MonadAdaptor[Future] = new MonadAdaptor[Future] {
+      def executeRequest(service: OAuthService, request: OAuthRequest): Future[Response] = {
+        val javaFuture = service.executeAsync(request)
+        CompletableFuture.supplyAsync(new Supplier[Response] {
+          def get(): Response = javaFuture.get()
+        }).toScala
+      }
+    }
+  }
+}

--- a/src/main/scala/software/purpledragon/sttp/scribe/ScribeOAuth10aBackend.scala
+++ b/src/main/scala/software/purpledragon/sttp/scribe/ScribeOAuth10aBackend.scala
@@ -20,6 +20,7 @@ import com.github.scribejava.core.exceptions.OAuthException
 import com.github.scribejava.core.model.{OAuth1AccessToken, OAuthRequest, Response, Verb}
 import com.github.scribejava.core.oauth.OAuth10aService
 import software.purpledragon.sttp.scribe.QueryParamEncodingStyle.Sttp
+import sttp.client.monad.MonadError
 
 object ScribeOAuth10aBackend {
   private val TokenExpiredPattern = ".*oauth_problem=token_expired.*".r
@@ -32,17 +33,17 @@ object ScribeOAuth10aBackend {
   }
 }
 
-class ScribeOAuth10aBackend(
+class ScribeOAuth10aBackend[F[_]: MonadAdaptor: MonadError](
     service: OAuth10aService,
     tokenProvider: OAuth1TokenProvider,
     isTokenExpiredResponse: TokenExpiredResponseCheck = ScribeOAuth10aBackend.DefaultTokenExpiredCheck,
     encodingStyle: QueryParamEncodingStyle = Sttp
-) extends ScribeBackend(service, isTokenExpiredResponse, encodingStyle)
+) extends ScribeBackend[F](service, isTokenExpiredResponse, encodingStyle)
     with Logging {
 
   private var oauthToken: Option[OAuth1AccessToken] = None
 
-  override final def withEncodingStyle(style: QueryParamEncodingStyle): ScribeOAuth10aBackend = {
+  override final def withEncodingStyle(style: QueryParamEncodingStyle): ScribeOAuth10aBackend[F] = {
     new ScribeOAuth10aBackend(service, tokenProvider, isTokenExpiredResponse, style)
   }
 

--- a/src/main/scala/software/purpledragon/sttp/scribe/ScribeOAuth20Backend.scala
+++ b/src/main/scala/software/purpledragon/sttp/scribe/ScribeOAuth20Backend.scala
@@ -20,6 +20,7 @@ import com.github.scribejava.core.exceptions.OAuthException
 import com.github.scribejava.core.model.{OAuth2AccessToken, OAuthRequest, Response}
 import com.github.scribejava.core.oauth.OAuth20Service
 import software.purpledragon.sttp.scribe.QueryParamEncodingStyle.Sttp
+import sttp.client.monad.MonadError
 
 object ScribeOAuth20Backend extends Logging {
   private val TokenExpiredHeaderName = "WWW-Authenticate"
@@ -36,18 +37,18 @@ object ScribeOAuth20Backend extends Logging {
   }
 }
 
-class ScribeOAuth20Backend(
+class ScribeOAuth20Backend[F[_]: MonadAdaptor: MonadError](
     service: OAuth20Service,
     tokenProvider: OAuth2TokenProvider,
     grantType: OAuth2GrantType = OAuth2GrantType.AuthorizationCode,
     isTokenExpiredResponse: TokenExpiredResponseCheck = ScribeOAuth20Backend.DefaultTokenExpiredCheck,
     encodingStyle: QueryParamEncodingStyle = Sttp
-) extends ScribeBackend(service, isTokenExpiredResponse, encodingStyle)
+) extends ScribeBackend[F](service, isTokenExpiredResponse, encodingStyle)
     with Logging {
 
   private var oauthToken: Option[OAuth2AccessToken] = None
 
-  override final def withEncodingStyle(style: QueryParamEncodingStyle): ScribeOAuth20Backend = {
+  override final def withEncodingStyle(style: QueryParamEncodingStyle): ScribeOAuth20Backend[F] = {
     new ScribeOAuth20Backend(service, tokenProvider, grantType, isTokenExpiredResponse, style)
   }
 

--- a/src/test/scala/software/purpledragon/sttp/scribe/ScribeOAuth10aBackendSpec.scala
+++ b/src/test/scala/software/purpledragon/sttp/scribe/ScribeOAuth10aBackendSpec.scala
@@ -355,7 +355,7 @@ class ScribeOAuth10aBackendSpec extends AnyFlatSpec with Matchers with MockFacto
   }
 
   private trait ScribeOAuth10aFutureFixture extends ScribeOAuth10aFixtureBase {
-    private implicit val ec = ExecutionContext.Implicits.global
+    private implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
     protected implicit val monadError: MonadError[Future] = new FutureMonad
 
     protected implicit val backend: SttpBackend[Future, Nothing, NothingT] =

--- a/src/test/scala/software/purpledragon/sttp/scribe/ScribeOAuth20BackendSpec.scala
+++ b/src/test/scala/software/purpledragon/sttp/scribe/ScribeOAuth20BackendSpec.scala
@@ -371,7 +371,7 @@ class ScribeOAuth20BackendSpec extends AnyFlatSpec with Matchers with MockFactor
     val requestCaptor: CaptureAll[OAuthRequest] = CaptureAll[OAuthRequest]()
 
     // common request parts
-    (tokenProvider.accessTokenForRequest _).expects().returning(accessToken).once()
+    (() => tokenProvider.accessTokenForRequest).expects().returning(accessToken).once()
     (oauthService.signRequest(_: OAuth2AccessToken, _: OAuthRequest)).expects(accessToken, capture(requestCaptor))
 
     protected def stubResponse(response: TestResponse): Unit
@@ -400,7 +400,7 @@ class ScribeOAuth20BackendSpec extends AnyFlatSpec with Matchers with MockFactor
   }
 
   private trait ScribeOAuth20FutureFixture extends ScribeOAuth20FixtureBase {
-    private implicit val ec = ExecutionContext.Implicits.global
+    private implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
     protected implicit val monadError: MonadError[Future] = new FutureMonad
 
     protected implicit val backend: SttpBackend[Future, Nothing, NothingT] =

--- a/src/test/scala/software/purpledragon/sttp/scribe/ScribeOAuth20BackendSpec.scala
+++ b/src/test/scala/software/purpledragon/sttp/scribe/ScribeOAuth20BackendSpec.scala
@@ -26,9 +26,8 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import software.purpledragon.sttp.scribe.MonadAdaptor.Implicits._
 import sttp.client._
-import sttp.client.monad.{IdMonad, MonadError}
+import sttp.client.monad.{FutureMonad, IdMonad, MonadError}
 import sttp.model.{MediaType, StatusCode}
-import sttp.client.monad.FutureMonad
 
 import java.util.concurrent.CompletableFuture
 import scala.concurrent.{ExecutionContext, Future}

--- a/src/test/scala/software/purpledragon/sttp/scribe/ScribeOAuth20BackendSpec.scala
+++ b/src/test/scala/software/purpledragon/sttp/scribe/ScribeOAuth20BackendSpec.scala
@@ -21,13 +21,21 @@ import com.github.scribejava.core.model.{OAuth2AccessToken, OAuthRequest, Verb}
 import com.github.scribejava.core.oauth.OAuth20Service
 import org.scalamock.matchers.ArgCapture.CaptureAll
 import org.scalamock.scalatest.MockFactory
+import org.scalatest.concurrent.Eventually
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import software.purpledragon.sttp.scribe.MonadAdaptor.Implicits._
 import sttp.client._
+import sttp.client.monad.{IdMonad, MonadError}
 import sttp.model.{MediaType, StatusCode}
+import sttp.client.monad.FutureMonad
+
+import java.util.concurrent.CompletableFuture
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Success
 
 // scalastyle:off null
-class ScribeOAuth20BackendSpec extends AnyFlatSpec with Matchers with MockFactory with ScribeHelpers {
+class ScribeOAuth20BackendSpec extends AnyFlatSpec with Matchers with MockFactory with ScribeHelpers with Eventually {
 
   "ScribeOAuth20Backend" should "send get request" in new ScribeOAuth20Fixture {
     // given
@@ -327,7 +335,34 @@ class ScribeOAuth20BackendSpec extends AnyFlatSpec with Matchers with MockFactor
     )
   }
 
-  private trait ScribeOAuth20Fixture {
+  it should "be able to execute requests asynchronously" in new ScribeOAuth20FutureFixture {
+    // given
+    stubResponses(
+      StringResponse("OK")
+    )
+
+    // when
+    val result: Future[Response[Either[String, String]]] = basicRequest
+      .get(uri"https://example.com/api/test")
+      .send()
+
+    // then
+    eventually {
+      result.isCompleted shouldBe true
+      result.value match {
+        case Some(Success(r)) =>
+          r.code shouldBe StatusCode.Ok
+          r.body shouldBe Right("OK")
+        case _ => fail("unexpected error")
+      }
+    }
+
+    verifyRequests(
+      RequestExpectation("https://example.com/api/test")
+    )
+  }
+
+  private trait ScribeOAuth20FixtureBase {
     val oauthService: OAuth20Service = mock[OAuth20Service]
     val tokenProvider: OAuth2TokenProvider = mock[OAuth2TokenProvider]
 
@@ -340,13 +375,10 @@ class ScribeOAuth20BackendSpec extends AnyFlatSpec with Matchers with MockFactor
     (tokenProvider.accessTokenForRequest _).expects().returning(accessToken).once()
     (oauthService.signRequest(_: OAuth2AccessToken, _: OAuthRequest)).expects(accessToken, capture(requestCaptor))
 
-    protected implicit val backend: SttpBackend[Identity, Nothing, NothingT] =
-      new ScribeOAuth20Backend(oauthService, tokenProvider)
+    protected def stubResponse(response: TestResponse): Unit
 
     protected def stubResponses(responses: TestResponse*): Unit = {
-      responses foreach { response =>
-        (oauthService.execute(_: OAuthRequest)).expects(*).returning(response.toResponse)
-      }
+      responses.foreach(stubResponse)
     }
 
     protected def verifyRequests(requests: RequestExpectation*): Unit = {
@@ -355,6 +387,31 @@ class ScribeOAuth20BackendSpec extends AnyFlatSpec with Matchers with MockFactor
       requestCaptor.values.zip(requests) foreach { case (request, expected) =>
         expected.verify(request)
       }
+    }
+  }
+
+  private trait ScribeOAuth20Fixture extends ScribeOAuth20FixtureBase {
+    protected implicit val monadError: MonadError[Identity] = IdMonad
+    protected implicit val backend: SttpBackend[Identity, Nothing, NothingT] =
+      new ScribeOAuth20Backend(oauthService, tokenProvider)
+
+    protected def stubResponse(response: TestResponse): Unit = {
+      (oauthService.execute(_: OAuthRequest)).expects(*).returning(response.toResponse)
+    }
+  }
+
+  private trait ScribeOAuth20FutureFixture extends ScribeOAuth20FixtureBase {
+    private implicit val ec = ExecutionContext.Implicits.global
+    protected implicit val monadError: MonadError[Future] = new FutureMonad
+
+    protected implicit val backend: SttpBackend[Future, Nothing, NothingT] =
+      new ScribeOAuth20Backend(oauthService, tokenProvider)
+
+    protected def stubResponse(response: TestResponse): Unit = {
+      (oauthService
+        .executeAsync(_: OAuthRequest))
+        .expects(*)
+        .returning(CompletableFuture.completedFuture(response.toResponse))
     }
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.4-SNAPSHOT"
+ThisBuild / version := "3.0.0-SNAPSHOT"


### PR DESCRIPTION
Allows use of the sttp-scribe backend asynchronously, using `OAuthService.executeAsync` to execute requests.

- Should this be a minor/major version bump?